### PR TITLE
Implement DFF state handling and add counter tests

### DIFF
--- a/v2m/evaluator/src/pin_binding.rs
+++ b/v2m/evaluator/src/pin_binding.rs
@@ -7,7 +7,7 @@ use v2m_formats::{resolve_bitref, ResolvedBit};
 use v2m_nir::ModuleGraph;
 use v2m_nir::NetId;
 
-const LANE_BITS: u32 = 64;
+pub(crate) const LANE_BITS: u32 = 64;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct ConstId(pub(crate) usize);


### PR DESCRIPTION
## Summary
- track flip-flop state in the evaluator by staging register outputs, capturing next values, and updating packed storage
- expose helpers to read current and next register values and look up registers by name
- build counter NIR fixtures and add tests that verify 1-bit and 32-bit counters advance correctly

## Testing
- `cargo test -p v2m-evaluator`


------
https://chatgpt.com/codex/tasks/task_e_68cada61e8f88323abc4190a2fb7b0a1