### PR TITLE
Optimize ModuleGraph adjacency construction

### DIFF
--- a/v2m/Cargo.lock
+++ b/v2m/Cargo.lock
@@ -975,6 +975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,8 +1326,10 @@ dependencies = [
  "num-bigint",
  "proptest",
  "rand 0.8.5",
+ "rustc-hash",
  "serde",
  "serde_json",
+ "smallvec",
  "tempfile",
  "thiserror",
  "v2m-evaluator",

--- a/v2m/core/nir/Cargo.toml
+++ b/v2m/core/nir/Cargo.toml
@@ -9,6 +9,8 @@ v2m-formats = { path = "../formats" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
+rustc-hash = "1.1"
+smallvec = "1.11"
 
 [dev-dependencies]
 v2m-formats = { path = "../formats" }


### PR DESCRIPTION
## Summary
- switch ModuleGraph::from_module to FxHashMap lookups and SmallVec-backed adjacency buffers so we avoid repeated BTreeSet allocations while keeping deterministic ordering
- add the rustc-hash and smallvec dependencies required for the new data structures
- add a regression test that exercises a multi-driver net

## Testing
- cargo test -p v2m-nir

------
https://chatgpt.com/codex/tasks/task_e_68cb3e46c8f88323af490bda1597b705