### PR TITLE
Avoid cloning evaluation order in normalizer

### DIFF
--- a/v2m/core/nir/src/normalize.rs
+++ b/v2m/core/nir/src/normalize.rs
@@ -363,8 +363,8 @@ impl<'a> Normalizer<'a> {
     }
 
     fn evaluate_combinational_nodes(&mut self) -> Result<(), NormalizeError> {
-        let order = self.order.clone();
-        for node_id in order {
+        let order = std::mem::take(&mut self.order);
+        for &node_id in &order {
             let op = self.graph.node(node_id).op().clone();
             if matches!(op, NodeOp::Dff | NodeOp::Latch) {
                 continue;
@@ -383,11 +383,12 @@ impl<'a> Normalizer<'a> {
                 NodeOp::Slice => self.compute_slice(node_id, node)?,
                 NodeOp::Cat => self.compute_cat(node_id, node)?,
                 NodeOp::Const => self.compute_const(node_id, node)?,
-                NodeOp::Dff | NodeOp::Latch => continue,
+                NodeOp::Dff | NodeOp::Latch => unreachable!("sequential op handled above"),
             };
 
             self.assign_node_outputs(node_id, node, outputs)?;
         }
+        self.order = order;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- iterate the combinational evaluation order without cloning the node IDs by temporarily taking the vector and iterating by reference
- keep the node metadata borrowed while dispatching helper routines and restore the order afterward

## Testing
- cargo test -p v2m-nir normalize

------
https://chatgpt.com/codex/tasks/task_e_68cc5cba9b3c8323a488d763471ae9a2